### PR TITLE
Add location and comment printer properties to Printer role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## unreleased
+
+* Cast type _lprQueueName_ as [string] to support Ansible Win_DSC module
+* Added additional printer properties for deployments
+  * Location
+  * Comment
+  * Published
+
 ## 2.0.0.0
 
 * Fixed examples for deployment

--- a/DSCClassResources/Printer/Printer.psm1
+++ b/DSCClassResources/Printer/Printer.psm1
@@ -170,8 +170,6 @@ class Printer
                     Name       = $this.Name
                     PortName   = $this.PortName
                     DriverName = $this.DriverName
-                    Location   = $this.Location
-                    Comment    = $this.Comment
                 }
                 if ($null -ne $this.PermissionSDDL)
                 {
@@ -181,6 +179,14 @@ class Printer
                 {
                     $addPrinterParam.Shared = $this.Shared
                 } # end if shared
+                if ($null -ne $this.Location)
+                {
+                    $addPrinterParam.Location = $this.Location
+                } # end if Location
+                if ($null -ne $this.Comment)
+                {
+                    $addPrinterParam.Comment = $this.Comment
+                } # end if Comment
 
                 try
                 {
@@ -520,12 +526,12 @@ class Printer
                 Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "PortName", $printer.PortName, $this.PortName)
                 return $false
             } # End PortName
-            if ($this.Location -ne $printer.Location)
+            if ($this.Location -ne [string]$printer.Location)
             {
                 Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Location", $printer.Location, $this.Location)
                 return $false
             } # End Location
-            if ($this.Comment -ne $printer.Comment)
+            if ($this.Comment -ne [string]$printer.Comment)
             {
                 Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Comment", $printer.Comment, $this.Comment)
                 return $false
@@ -573,7 +579,7 @@ class Printer
                         } # End SNMPIndex
                     } # End SNMPIndex
 
-                    if ($this.lprQueueName -ne $printerPort.lprQueueName)
+                    if ([string]$this.lprQueueName -ne [string]$printerPort.lprQueueName)
                     {
                         Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "lprQueueName", $printerPort.lprQueueName, $this.lprQueueName)
                         return $false

--- a/DSCClassResources/Printer/Printer.psm1
+++ b/DSCClassResources/Printer/Printer.psm1
@@ -65,6 +65,10 @@ class Printer
     [System.String]
     $Comment
 
+    [DscProperty()]
+    [System.Boolean]
+    $Published = $false
+
     hidden $Messages = ""
 
     Printer()
@@ -187,6 +191,10 @@ class Printer
                 {
                     $addPrinterParam.Comment = $this.Comment
                 } # end if Comment
+                if ($null -ne $this.Published)
+                {
+                    $addPrinterParam.Published = $this.Published
+                } # end if Published
 
                 try
                 {
@@ -266,6 +274,14 @@ class Printer
                     # To make changes we need to make sure there are no jobs queued up on the printer
                     Get-PrintJob -PrinterName $this.Name | Remove-PrintJob
                 } # End If Comment
+
+                if ($printer.Published -ne $this.Published)
+                {
+                    $updatePrinterParam.Published = $this.Published
+                    Write-Verbose -Message ($this.Messages.UpdatedDesiredState -f 'Published', $this.Published, $printer.Published)
+                    # To make changes we need to make sure there are no jobs queued up on the printer
+                    Get-PrintJob -PrinterName $this.Name | Remove-PrintJob
+                } # End If Published
 
                 <#
                     If the no params are added besides the default name property.
@@ -536,6 +552,11 @@ class Printer
                 Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Comment", $printer.Comment, $this.Comment)
                 return $false
             } # End Comment
+            if ($this.Published -ne $printer.Published)
+            {
+                Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Published", $printer.Published, $this.Published)
+                return $false
+            } # End Published
 
             switch ($printerPort.Description)
             {
@@ -637,6 +658,7 @@ class Printer
             $ReturnObject.PermissionSDDL = $printer.PermissionSDDL
             $ReturnObject.Location = $printer.Location
             $ReturnObject.Comment = $printer.Comment
+            $ReturnObject.Published = $printer.Published
         } # End Printer
         if ($null -ne $printerPort)
         {

--- a/DSCClassResources/Printer/Printer.psm1
+++ b/DSCClassResources/Printer/Printer.psm1
@@ -57,6 +57,14 @@ class Printer
     [System.String]
     $lprQueueName
 
+    [DscProperty()]
+    [System.String]
+    $Location
+
+    [DscProperty()]
+    [System.String]
+    $Comment
+
     hidden $Messages = ""
 
     Printer()
@@ -162,6 +170,8 @@ class Printer
                     Name       = $this.Name
                     PortName   = $this.PortName
                     DriverName = $this.DriverName
+                    Location   = $this.Location
+                    Comment    = $this.Comment
                 }
                 if ($null -ne $this.PermissionSDDL)
                 {
@@ -234,6 +244,22 @@ class Printer
                     # To make changes we need to make sure there are no jobs queued up on the printer
                     Get-PrintJob -PrinterName $this.Name | Remove-PrintJob
                 } # End If PrinterPort
+
+                if ($printer.Location -ne $this.Location)
+                {
+                    $updatePrinterParam.Location = $this.Location
+                    Write-Verbose -Message ($this.Messages.UpdatedDesiredState -f 'Location', $this.Location, $printer.Location)
+                    # To make changes we need to make sure there are no jobs queued up on the printer
+                    Get-PrintJob -PrinterName $this.Name | Remove-PrintJob
+                } # End If Location
+                
+                if ($printer.Comment -ne $this.Comment)
+                {
+                    $updatePrinterParam.Comment = $this.Comment
+                    Write-Verbose -Message ($this.Messages.UpdatedDesiredState -f 'Comment', $this.Comment, $printer.Comment)
+                    # To make changes we need to make sure there are no jobs queued up on the printer
+                    Get-PrintJob -PrinterName $this.Name | Remove-PrintJob
+                } # End If Comment
 
                 <#
                     If the no params are added besides the default name property.
@@ -494,6 +520,16 @@ class Printer
                 Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "PortName", $printer.PortName, $this.PortName)
                 return $false
             } # End PortName
+            if ($this.Location -ne $printer.Location)
+            {
+                Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Location", $printer.Location, $this.Location)
+                return $false
+            } # End Location
+            if ($this.Comment -ne $printer.Comment)
+            {
+                Write-Verbose -Message  ($this.Messages.NotInDesiredState -f "Comment", $printer.Comment, $this.Comment)
+                return $false
+            } # End Comment
 
             switch ($printerPort.Description)
             {
@@ -593,6 +629,8 @@ class Printer
             $ReturnObject.DriverName = $printer.DriverName
             $ReturnObject.Shared = $printer.Shared
             $ReturnObject.PermissionSDDL = $printer.PermissionSDDL
+            $ReturnObject.Location = $printer.Location
+            $ReturnObject.Comment = $printer.Comment
         } # End Printer
         if ($null -ne $printerPort)
         {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Manages printers installed on a host.
 * **`[UInt32]` SNMPIndex** _(Write)_: The desired index used for SNMP communication. Requires SNMPCommunity to also be set. This will enable SNMP on the port
     The default value is 1.
 * **`[String]` PermissionsSDDL** _(Write)_: The desired permissions of a printer
+* **`[String]` Location** _(Write)_: The desired Location property of a printer
+* **`[String]` Comment** _(Write)_: The desired Comment property of a printer
 
 #### Examples Printer
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Manages printers installed on a host.
 * **`[String]` PermissionsSDDL** _(Write)_: The desired permissions of a printer
 * **`[String]` Location** _(Write)_: The desired Location property of a printer
 * **`[String]` Comment** _(Write)_: The desired Comment property of a printer
+* **`[Boolean]` Published** _(Write)_: The desired Published property of a printer. Requires the host is joined to an Active Directory domain. The default value is $false.
 
 #### Examples Printer
 


### PR DESCRIPTION
I'm using this DSC module as a part of an Ansible deployment. Casting the Printer/Location/lprQueueName  properties as string prevents Ansible from detecting a change when comparing `$null` against an empty string.

I wasn't able to get the tests to work on my end, so I didnt update the tests.
I think I'm missing a dependency:
```
Executing script C:\Program Files\WindowsPowerShell\Modules\PrintManagementDsc\Tests\Unit\Printer.tests.ps1
  [-] Error occurred in test script 'C:\Program Files\WindowsPowerShell\Modules\PrintManagementDsc\Tests\Unit\Printer.tests.ps1' 0ms
    RuntimeException: Cannot find the type for custom attribute 'Microsoft.DscResourceKit.UnitTest'. Make sure that the assembly that contains this type is loaded.
    at <ScriptBlock>, C:\Program Files\WindowsPowerShell\Modules\Pester\4.10.0\Pester.psm1: line 1111
    at Invoke-Pester<End>, C:\Program Files\WindowsPowerShell\Modules\Pester\4.10.0\Pester.psm1: line 1137
    at Invoke-TestHarness, C:\Program Files\WindowsPowerShell\Modules\PrintManagementDsc\Tests\TestHarness.psm1: line 65
```
I've cloned your `Microsoft.DscResourceKit.UnitTest` repo, but that didnt seem to satisfy that error.