### PR TITLE
Change PaperCut port detection.

### DIFF
--- a/DSCClassResources/Printer/Printer.psm1
+++ b/DSCClassResources/Printer/Printer.psm1
@@ -733,7 +733,7 @@ class Printer
                 return [PortType]::LPR
             } # End 2
         } # End Switch
-        if ($getPortInformation.Description -eq "PaperCut TCP/IP Port")
+        if (Test-Path -Path ("HKLM:\SYSTEM\CurrentControlSet\Control\Print\Monitors\PaperCut TCP/IP Port\Ports\{0}" -f $this.PortName))
         {
             return [PortType]::PaperCut
         } # End If Description


### PR DESCRIPTION
In my environment the FindPortType function in Printer.psm1 returns $null for PaperCut ports because Get-CimInstance -Query ("Select Protocol,Description From Win32_TCPIpPrinterPort") doesn't return PaperCut ports (only TCP/IP ports).  
This causes errors when applying a DSC configuration where the PaperCut port exists.
I've updated the function to query "HKLM:\SYSTEM\CurrentControlSet\Control\Print\Monitors\PaperCut TCP/IP Port\Ports\" to detect if the port is a PaperCut port.